### PR TITLE
Fix csharp_space_between_parentheses

### DIFF
--- a/src/Schema/EditorConfig.json
+++ b/src/Schema/EditorConfig.json
@@ -481,9 +481,8 @@
     },
     {
       "name": "csharp_space_between_parentheses",
-      "description": "Undocumented property",
-      "values": [ "expressions", "type_casts", "control_flow_statements" ],
-      "hidden": true
+      "description": "Space Within Parentheses for Other Options",
+      "values": [ "expressions", "type_casts", "control_flow_statements", false ]
     },
     {
       "name": "csharp_space_between_square_brackets",


### PR DESCRIPTION
It is now documented. See https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference#space_other