### PR TITLE
Unhide documented properties

### DIFF
--- a/src/Schema/EditorConfig.json
+++ b/src/Schema/EditorConfig.json
@@ -187,6 +187,56 @@
       "description": "Place query expression clauses on new line.",
       "values": [ true, false ]
     },
+    {
+      "name": "csharp_indent_case_contents",
+      "description": "Indent switch case contents.",
+      "values": [ true, false ]
+    },
+    {
+      "name": "csharp_indent_labels",
+      "description": "Label Positioning.",
+      "values": [ "flush_left", "no_change", "one_less_than_current" ]
+    },
+    {
+      "name": "csharp_indent_switch_labels",
+      "description": "Indent switch Labels.",
+      "values": [ true, false ]
+    },
+    {
+      "name": "csharp_preserve_single_line_blocks",
+      "description": "Leave Block on Single Line.",
+      "values": [ true, false ]
+    },
+    {
+      "name": "csharp_preserve_single_line_statements",
+      "description": "Leave Statements and Member Declarations on the Same Line.",
+      "values": [ true, false ]
+    },
+    {
+      "name": "csharp_space_after_cast",
+      "description": "Require a space between a cast and the value.",
+      "values": [ true, false ]
+    },
+    {
+      "name": "csharp_space_after_keywords_in_control_flow_statements",
+      "description": "Space After Keywords in Control Flow Statements.",
+      "values": [ true, false ]
+    },
+    {
+      "name": "csharp_space_between_method_call_parameter_list_parentheses",
+      "description": "Space Within Parentheses for Method Call Argument List.",
+      "values": [ true, false ]
+    },
+    {
+      "name": "csharp_space_between_method_declaration_parameter_list_parentheses",
+      "description": "Space Between Method Declaration Argument-List Parentheses.",
+      "values": [ true, false ]
+    },
+    {
+      "name": "csharp_space_between_parentheses",
+      "description": "Space Within Parentheses for Other Options.",
+      "values": [ "expressions", "type_casts", "control_flow_statements", false ]
+    },
 
     // .NET properties
     {
@@ -330,42 +380,6 @@
       "hidden": true
     },
     {
-      "name": "csharp_indent_case_contents",
-      "description": "Undocumented property",
-      "values": [ true, false ],
-      "hidden": true
-    },
-    {
-      "name": "csharp_indent_labels",
-      "description": "Undocumented property",
-      "values": [ "flush_left", "no_change", "one_less_than_current" ],
-      "hidden": true
-    },
-    {
-      "name": "csharp_indent_switch_labels",
-      "description": "Undocumented property",
-      "values": [ true, false ],
-      "hidden": true
-    },
-    {
-      "name": "csharp_preserve_single_line_blocks",
-      "description": "Undocumented property",
-      "values": [ true, false ],
-      "hidden": true
-    },
-    {
-      "name": "csharp_preserve_single_line_statements",
-      "description": "Undocumented property",
-      "values": [ true, false ],
-      "hidden": true
-    },
-    {
-      "name": "csharp_space_after_cast",
-      "description": "Undocumented property",
-      "values": [ true, false ],
-      "hidden": true
-    },
-    {
       "name": "csharp_space_after_colon_in_inheritance_clause",
       "description": "Undocumented property",
       "values": [ true, false ],
@@ -379,12 +393,6 @@
     },
     {
       "name": "csharp_space_after_dot",
-      "description": "Undocumented property",
-      "values": [ true, false ],
-      "hidden": true
-    },
-    {
-      "name": "csharp_space_after_keywords_in_control_flow_statements",
       "description": "Undocumented property",
       "values": [ true, false ],
       "hidden": true
@@ -456,12 +464,6 @@
       "hidden": true
     },
     {
-      "name": "csharp_space_between_method_call_parameter_list_parentheses",
-      "description": "Undocumented property",
-      "values": [ true, false ],
-      "hidden": true
-    },
-    {
       "name": "csharp_space_between_method_declaration_empty_parameter_list_parentheses",
       "description": "Undocumented property",
       "values": [ true, false ],
@@ -472,17 +474,6 @@
       "description": "Undocumented property",
       "values": [ true, false ],
       "hidden": true
-    },
-    {
-      "name": "csharp_space_between_method_declaration_parameter_list_parentheses",
-      "description": "Undocumented property",
-      "values": [ true, false ],
-      "hidden": true
-    },
-    {
-      "name": "csharp_space_between_parentheses",
-      "description": "Space Within Parentheses for Other Options",
-      "values": [ "expressions", "type_casts", "control_flow_statements", false ]
     },
     {
       "name": "csharp_space_between_square_brackets",


### PR DESCRIPTION
All these properties are documented on MS Docs: https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference

I also checked the other undocumented properties, they are all still on Roslyn's source code, but not yet documented on MS Docs.