### PR TITLE
Fix keywords and values

### DIFF
--- a/src/Schema/EditorConfig.json
+++ b/src/Schema/EditorConfig.json
@@ -183,7 +183,7 @@
       "multiple": true
     },
     {
-      "name": "csharp_new_line_between_query_expression_clauses",
+      "name": "csharp_new_line_within_query_expression_clauses",
       "description": "Place query expression clauses on new line.",
       "values": [ true, false ]
     },
@@ -195,7 +195,7 @@
     {
       "name": "csharp_indent_labels",
       "description": "Label Positioning.",
-      "values": [ "flush_left", "no_change", "one_less_than_current" ]
+      "values": [ "one_less", "no_change" ]
     },
     {
       "name": "csharp_indent_switch_labels",


### PR DESCRIPTION
Fixed issue with the "csharp_new_line_within_query_expression_clauses" keyword being different

Fixed the allowed values for "csharp_indent_labels"

Source: https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference 