### PR TITLE
Fixing attribute name to match roslyn code

### DIFF
--- a/src/Schema/EditorConfig.json
+++ b/src/Schema/EditorConfig.json
@@ -183,7 +183,7 @@
       "multiple": true
     },
     {
-      "name": "csharp_new_line_within_query_expression_clauses",
+      "name": "csharp_new_line_between_query_expression_clauses",
       "description": "Place query expression clauses on new line.",
       "values": [ true, false ]
     },


### PR DESCRIPTION
Fixing this change from a few days ago. The Microsoft documentation was corrected to accurately show the true value from the [roslyn code](https://github.com/dotnet/roslyn/blob/9d081e899b35294b8f1793d31abe5e2c43698844/src/Workspaces/CSharp/Portable/Formatting/CSharpFormattingOptions.cs#L243) on this attribute. Here is the [PR](https://github.com/MicrosoftDocs/visualstudio-docs/pull/272) for the documentation.  And this here is the [link](https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference) to the documentation for confirmation on this change.