### PR TITLE
Allow multiple values for csharp_space_between_parentheses

### DIFF
--- a/src/Schema/EditorConfig.json
+++ b/src/Schema/EditorConfig.json
@@ -236,6 +236,7 @@
       "name": "csharp_space_between_parentheses",
       "description": "Space Within Parentheses for Other Options.",
       "values": [ "expressions", "type_casts", "control_flow_statements", false ]
+      "multiple": true
     },
     {
       "name": "csharp_prefer_braces",


### PR DESCRIPTION
The MSDN documentation uses multiple values in the example https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference

I *think* that's all I needed to change, let me know if there was something else I missed.