### PR TITLE
Add validation on unknown style

### DIFF
--- a/src/Resources/Text.Designer.cs
+++ b/src/Resources/Text.Designer.cs
@@ -19,7 +19,7 @@ namespace EditorConfig.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Text {
@@ -224,7 +224,7 @@ namespace EditorConfig.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Spces in globbing patterns are allowed, but are often the result of a typo. Make sure the globbing pattern is accurate..
+        ///   Looks up a localized string similar to Spaces in globbing patterns are allowed, but are often the result of a typo. Make sure the globbing pattern is accurate..
         /// </summary>
         internal static string ValidationSpaceInSection {
             get {
@@ -247,6 +247,15 @@ namespace EditorConfig.Resources {
         internal static string ValidationUnknownElement {
             get {
                 return ResourceManager.GetString("ValidationUnknownElement", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The style &quot;{0}&quot; is unknown. A capitalization style must always be specified..
+        /// </summary>
+        internal static string ValidationUnknownStyle {
+            get {
+                return ResourceManager.GetString("ValidationUnknownStyle", resourceCulture);
             }
         }
         

--- a/src/Resources/Text.resx
+++ b/src/Resources/Text.resx
@@ -181,6 +181,9 @@
   <data name="ValidationUnknownElement" xml:space="preserve">
     <value>Syntax error. Element not valid at current location.</value>
   </data>
+  <data name="ValidationUnknownStyle" xml:space="preserve">
+    <value>The style "{0}" is unknown. A capitalization style must always be specified.</value>
+  </data>
   <data name="ValueUnset" xml:space="preserve">
     <value>For any standard property, a value of "unset" is to remove the effect of that property, even if it has been set before.</value>
   </data>

--- a/src/Validation/EditorConfigValidatorRules.cs
+++ b/src/Validation/EditorConfigValidatorRules.cs
@@ -86,6 +86,14 @@ namespace EditorConfig
                             }
                         }
                     });
+
+                    ErrorCatalog.UnknownStyle.Run(property.Keyword, IsDotNetNamingRuleStyle(property), (e) =>
+                    {
+                        if (!section.Properties.Any(x => x.Keyword.Text.Is($"dotnet_naming_style.{property.Value.Text}.capitalization")))
+                        {
+                            e.Register(property.Value, property.Value.Text);
+                        }
+                    });
                 }
 
                 ErrorCatalog.SectionSyntaxError.Run(section.Item, (e) =>
@@ -266,5 +274,9 @@ namespace EditorConfig
 
             return false;
         }
+
+        private static bool IsDotNetNamingRuleStyle(Property property) 
+            => property.Keyword.Text.StartsWith("dotnet_naming_rule", StringComparison.Ordinal) && 
+               property.Keyword.Text.EndsWith("style", StringComparison.Ordinal);
     }
 }

--- a/src/Validation/ErrorCatalog.cs
+++ b/src/Validation/ErrorCatalog.cs
@@ -51,6 +51,8 @@ namespace EditorConfig
             Create("EC116", ErrorCategory.Suggestion, Resources.Text.ValidationIndentSizeUnneeded);
         public static Error SpaceInSection { get; } =
             Create("EC117", ErrorCategory.Suggestion, Resources.Text.ValidationSpaceInSection, () => !_o.AllowSpacesInSections);
+        public static Error UnknownStyle { get; } =
+            Create("EC118", ErrorCategory.Error, Resources.Text.ValidationUnknownStyle);
 
         public static bool TryGetErrorCode(string code, out Error errorCode)
         {


### PR DESCRIPTION
In multiple issues created over at the Roslyn repo (like [this one](https://github.com/dotnet/roslyn/issues/22886)), people reported crashes because of an unknown style being referenced in the .editorconfig. 

Though this crash will be handled in the future (a fix for it has been pushed to the Roslyn master), it would be very helpful to provide an error when you're referencing an unknown style. This pull request creates an extra validation for this.