### PR TITLE
Add validation on unused style

### DIFF
--- a/src/Resources/Text.Designer.cs
+++ b/src/Resources/Text.Designer.cs
@@ -260,6 +260,15 @@ namespace EditorConfig.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The style &quot;{0}&quot; is never used. Consider removing it..
+        /// </summary>
+        internal static string ValidationUnusedStyle {
+            get {
+                return ResourceManager.GetString("ValidationUnusedStyle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to For any standard property, a value of &quot;unset&quot; is to remove the effect of that property, even if it has been set before..
         /// </summary>
         internal static string ValueUnset {

--- a/src/Resources/Text.resx
+++ b/src/Resources/Text.resx
@@ -184,6 +184,9 @@
   <data name="ValidationUnknownStyle" xml:space="preserve">
     <value>The style "{0}" is unknown. A capitalization style must always be specified.</value>
   </data>
+  <data name="ValidationUnusedStyle" xml:space="preserve">
+    <value>The style "{0}" is never used. Consider removing it.</value>
+  </data>
   <data name="ValueUnset" xml:space="preserve">
     <value>For any standard property, a value of "unset" is to remove the effect of that property, even if it has been set before.</value>
   </data>

--- a/src/Validation/ErrorCatalog.cs
+++ b/src/Validation/ErrorCatalog.cs
@@ -53,6 +53,8 @@ namespace EditorConfig
             Create("EC117", ErrorCategory.Suggestion, Resources.Text.ValidationSpaceInSection, () => !_o.AllowSpacesInSections);
         public static Error UnknownStyle { get; } =
             Create("EC118", ErrorCategory.Error, Resources.Text.ValidationUnknownStyle);
+        public static Error UnusedStyle { get; } =
+            Create("EC119", ErrorCategory.Suggestion, Resources.Text.ValidationUnusedStyle);
 
         public static bool TryGetErrorCode(string code, out Error errorCode)
         {


### PR DESCRIPTION
These changes add a validation on unused naming styles. It helps to keep .editorconfig files clean by quickly showing you styles which you have defined, but are not referenced.