### PR TITLE
Fix getting analyzer error when using `**.ext`

### DIFF
--- a/src/Validation/EditorConfigValidatorRules.cs
+++ b/src/Validation/EditorConfigValidatorRules.cs
@@ -278,6 +278,7 @@ namespace EditorConfig
 
             if (!string.IsNullOrWhiteSpace(p))
             {
+                p = p.Replace("**", "{*,**/**/**}");
                 return Minimatcher.Check(path, p, _miniMatchOptions);
             }
 


### PR DESCRIPTION
Fixes #47

We could come up with a much better solution, I just copied this for now: [editorconfig-core-js/index.ts:49](https://github.com/editorconfig/editorconfig-core-js/blob/188a8e4bda06f2653557fa28c8bacc549e10645b/src/index.ts#L49).
This way, `**` matches 3 level subdirectories at maximum (`**/**/**`).

edit: I realized some test don't pass right after I opened the PR. I'm not gonna try to fix it until I get a go-ahead 'cause a rewrite of the `Minimatch` library might be better anyway.