### PR TITLE
Analyze naming rules

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <LangVersion>7.3</LangVersion>
+  </PropertyGroup>
+</Project>

--- a/src/EditorConfig.csproj
+++ b/src/EditorConfig.csproj
@@ -76,6 +76,17 @@
     <Compile Include="Validation\EditorConfigValidatorRules.cs" />
     <Compile Include="Validation\ErrorList\DisplayError.cs" />
     <Compile Include="Validation\Error.cs" />
+    <Compile Include="Validation\NamingStyles\Accessibility.cs" />
+    <Compile Include="Validation\NamingStyles\EditorConfigNamingStyleParser.cs" />
+    <Compile Include="Validation\NamingStyles\ModifierKind.cs" />
+    <Compile Include="Validation\NamingStyles\NamingRule.cs" />
+    <Compile Include="Validation\NamingStyles\NamingStyle.cs" />
+    <Compile Include="Validation\NamingStyles\NamingStylePreferences.cs" />
+    <Compile Include="Validation\NamingStyles\NamingStyleRules.cs" />
+    <Compile Include="Validation\NamingStyles\ReportDiagnostic.cs" />
+    <Compile Include="Validation\NamingStyles\SerializableNamingRule.cs" />
+    <Compile Include="Validation\NamingStyles\SymbolKindOrTypeKind.cs" />
+    <Compile Include="Validation\NamingStyles\SymbolSpecification.cs" />
     <Compile Include="Validation\Tagger\ErrorFormatDefinition.cs" />
     <Compile Include="Commands\CreateEditorConfigFileAnyCode.cs" />
     <Compile Include="Validation\ErrorList\SinkManager.cs" />
@@ -264,6 +275,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />

--- a/src/Resources/Text.Designer.cs
+++ b/src/Resources/Text.Designer.cs
@@ -19,7 +19,7 @@ namespace EditorConfig.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Text {
@@ -84,6 +84,15 @@ namespace EditorConfig.Resources {
         internal static string InvalidValue {
             get {
                 return ResourceManager.GetString("InvalidValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Naming rule &apos;{0}&apos; was reordered relative to overlapping rule &apos;{1}&apos;. Elements which match both will be validated against rule &apos;{0}&apos; starting with Visual Studio 2019 version 16.3..
+        /// </summary>
+        internal static string NamingRuleReordered {
+            get {
+                return ResourceManager.GetString("NamingRuleReordered", resourceCulture);
             }
         }
         

--- a/src/Resources/Text.resx
+++ b/src/Resources/Text.resx
@@ -126,6 +126,9 @@
   <data name="InvalidValue" xml:space="preserve">
     <value>"{0}" is not a valid value for the "{1}" property</value>
   </data>
+  <data name="NamingRuleReordered" xml:space="preserve">
+    <value>Naming rule '{0}' was reordered relative to overlapping rule '{1}'. Elements which match both will be validated against rule '{0}' starting with Visual Studio 2019 version 16.3.</value>
+  </data>
   <data name="NotSupportedByVS" xml:space="preserve">
     <value>Not supported by Visual Studio</value>
   </data>

--- a/src/Validation/EditorConfigValidatorRules.cs
+++ b/src/Validation/EditorConfigValidatorRules.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using EditorConfig.Validation.NamingStyles;
 using Microsoft.VisualStudio.Shell;
 using Minimatch;
 
@@ -141,7 +143,189 @@ namespace EditorConfig
                         e.Register(section.Item.Text);
                     }
                 });
+
+                ValidateNamingStyles(section);
             }
+        }
+
+        private void ValidateNamingStyles(Section section)
+        {
+            NamingStylePreferences namingStyle = EditorConfigNamingStyleParser.GetNamingStyles(section.Properties);
+
+            IOrderedEnumerable<NamingRule> orderedRules = namingStyle.Rules.NamingRules
+                .OrderBy(rule => rule, NamingRuleAccessibilityListComparer.Instance)
+                .ThenBy(rule => rule, NamingRuleModifierListComparer.Instance)
+                .ThenBy(rule => rule, NamingRuleSymbolListComparer.Instance)
+                .ThenBy(rule => rule.Name, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(rule => rule.Name, StringComparer.Ordinal);
+
+            var orderedRulePreferences = new NamingStylePreferences(
+                namingStyle.SymbolSpecifications,
+                namingStyle.NamingStyles,
+                orderedRules.Select(
+                    rule => new SerializableNamingRule
+                    {
+                        Name = rule.Name,
+                        SymbolSpecificationID = rule.SymbolSpecification.ID,
+                        NamingStyleID = rule.NamingStyle.ID,
+                        EnforcementLevel = rule.EnforcementLevel,
+                    }).ToImmutableArray());
+
+            var reorderedOverlappingRules = new List<(string firstRule, string secondRule)>();
+            ImmutableArray<NamingRule> declaredNamingRules = namingStyle.Rules.NamingRules;
+            ImmutableArray<NamingRule> orderedNamingRules = orderedRulePreferences.Rules.NamingRules;
+            for (int i = 0; i < declaredNamingRules.Length; i++)
+            {
+                for (int j = 0; j < i; j++)
+                {
+                    NamingRule firstRule = declaredNamingRules[j];
+                    NamingRule secondRule = declaredNamingRules[i];
+
+                    // If the reordered rules are in the same relative order, no need to check the overlap
+                    bool reordered = false;
+                    foreach (NamingRule rule in orderedNamingRules)
+                    {
+                        if (rule.Name == firstRule.Name)
+                        {
+                            break;
+                        }
+                        else if (rule.Name == secondRule.Name)
+                        {
+                            reordered = true;
+                            break;
+                        }
+                    }
+
+                    if (!reordered)
+                    {
+                        continue;
+                    }
+
+                    // If the rules don't overlap, reordering is not a problem
+                    if (!Overlaps(firstRule, secondRule))
+                    {
+                        continue;
+                    }
+
+                    reorderedOverlappingRules.Add((firstRule.Name, secondRule.Name));
+                }
+            }
+
+            var reportedRules = new HashSet<string>();
+            foreach (Property property in section.Properties)
+            {
+                string name = property.Keyword.Text.Trim();
+                if (!name.StartsWith("dotnet_naming_rule."))
+                {
+                    continue;
+                }
+
+                string[] nameSplit = name.Split('.');
+                if (nameSplit.Length != 3)
+                {
+                    continue;
+                }
+
+                string ruleName = nameSplit[1];
+                if (!reportedRules.Add(ruleName))
+                {
+                    continue;
+                }
+
+                foreach ((string firstRule, string secondRule) in reorderedOverlappingRules)
+                {
+                    if (secondRule != ruleName)
+                    {
+                        continue;
+                    }
+
+                    ErrorCatalog.NamingRuleReordered.Run(property.Keyword, e =>
+                    {
+                        e.Register(secondRule, firstRule);
+                    });
+                }
+            }
+        }
+
+        private bool Overlaps(in NamingRule x, in NamingRule y)
+        {
+            bool overlapAccessibility = false;
+            foreach (Accessibility accessibility in x.SymbolSpecification.ApplicableAccessibilityList)
+            {
+                if (y.SymbolSpecification.ApplicableAccessibilityList.Contains(accessibility))
+                {
+                    overlapAccessibility = true;
+                    break;
+                }
+            }
+
+            if (!overlapAccessibility)
+            {
+                return false;
+            }
+
+            bool overlapSymbols = false;
+            foreach (SymbolKindOrTypeKind symbolKind in x.SymbolSpecification.ApplicableSymbolKindList)
+            {
+                if (y.SymbolSpecification.ApplicableSymbolKindList.Contains(symbolKind))
+                {
+                    overlapSymbols = true;
+                    break;
+                }
+            }
+
+            if (!overlapSymbols)
+            {
+                return false;
+            }
+
+            if (x.SymbolSpecification.RequiredModifierList.IsEmpty || y.SymbolSpecification.RequiredModifierList.IsEmpty)
+            {
+                // Modifiers are the last check. If either is empty, it matches all so the rules must overlap.
+                return true;
+            }
+
+            foreach (ModifierKind modifier in x.SymbolSpecification.RequiredModifierList)
+            {
+                switch (modifier)
+                {
+                    case ModifierKind.IsAbstract:
+                        if (y.SymbolSpecification.RequiredModifierList.Contains(ModifierKind.IsStatic)
+                            || y.SymbolSpecification.RequiredModifierList.Contains(ModifierKind.IsConst))
+                        {
+                            return false;
+                        }
+
+                        break;
+
+                    case ModifierKind.IsStatic:
+                        if (y.SymbolSpecification.RequiredModifierList.Contains(ModifierKind.IsAbstract))
+                        {
+                            return false;
+                        }
+
+                        break;
+
+                    case ModifierKind.IsAsync:
+                        break;
+
+                    case ModifierKind.IsReadOnly:
+                        break;
+
+                    case ModifierKind.IsConst:
+                        if (y.SymbolSpecification.RequiredModifierList.Contains(ModifierKind.IsAbstract))
+                        {
+                            return false;
+                        }
+
+                        break;
+
+                    default:
+                        break;
+                }
+            }
+
+            return true;
         }
 
         private IEnumerable<EditorConfigDocument> GetAllParentDocuments()
@@ -294,5 +478,95 @@ namespace EditorConfig
 
         private static string GetDotNetNamingStyleText(Property property)
             => property.Keyword.Text.Split('.')[1];
+
+        private abstract class NamingRuleSubsetComparer : IComparer<NamingRule>
+        {
+            protected NamingRuleSubsetComparer()
+            {
+            }
+
+            public int Compare(NamingRule x, NamingRule y)
+            {
+                bool firstIsSubset = FirstIsSubset(in x, in y);
+                bool secondIsSubset = FirstIsSubset(in y, in x);
+                if (firstIsSubset)
+                {
+                    return secondIsSubset ? 0 : -1;
+                }
+                else
+                {
+                    return secondIsSubset ? 1 : 0;
+                }
+            }
+
+            protected abstract bool FirstIsSubset(in NamingRule x, in NamingRule y);
+        }
+
+        private sealed class NamingRuleAccessibilityListComparer : NamingRuleSubsetComparer
+        {
+            internal static readonly NamingRuleAccessibilityListComparer Instance = new NamingRuleAccessibilityListComparer();
+
+            private NamingRuleAccessibilityListComparer()
+            {
+            }
+
+            protected override bool FirstIsSubset(in NamingRule x, in NamingRule y)
+            {
+                foreach (Accessibility accessibility in x.SymbolSpecification.ApplicableAccessibilityList)
+                {
+                    if (!y.SymbolSpecification.ApplicableAccessibilityList.Contains(accessibility))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+        }
+
+        private sealed class NamingRuleModifierListComparer : NamingRuleSubsetComparer
+        {
+            internal static readonly NamingRuleModifierListComparer Instance = new NamingRuleModifierListComparer();
+
+            private NamingRuleModifierListComparer()
+            {
+            }
+
+            protected override bool FirstIsSubset(in NamingRule x, in NamingRule y)
+            {
+                // Since modifiers are "match all", a subset of symbols is matched by a superset of modifiers
+                foreach (ModifierKind modifier in y.SymbolSpecification.RequiredModifierList)
+                {
+                    if (!x.SymbolSpecification.RequiredModifierList.Contains(modifier))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+        }
+
+        private sealed class NamingRuleSymbolListComparer : NamingRuleSubsetComparer
+        {
+            internal static readonly NamingRuleSymbolListComparer Instance = new NamingRuleSymbolListComparer();
+
+            private NamingRuleSymbolListComparer()
+            {
+            }
+
+            protected override bool FirstIsSubset(in NamingRule x, in NamingRule y)
+            {
+                foreach (SymbolKindOrTypeKind symbolKind in x.SymbolSpecification.ApplicableSymbolKindList)
+                {
+                    if (!y.SymbolSpecification.ApplicableSymbolKindList.Contains(symbolKind))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+        }
     }
 }

--- a/src/Validation/EditorConfigValidatorRules.cs
+++ b/src/Validation/EditorConfigValidatorRules.cs
@@ -153,8 +153,8 @@ namespace EditorConfig
             NamingStylePreferences namingStyle = EditorConfigNamingStyleParser.GetNamingStyles(section.Properties);
 
             IOrderedEnumerable<NamingRule> orderedRules = namingStyle.Rules.NamingRules
-                .OrderBy(rule => rule, NamingRuleAccessibilityListComparer.Instance)
-                .ThenBy(rule => rule, NamingRuleModifierListComparer.Instance)
+                .OrderBy(rule => rule, NamingRuleModifierListComparer.Instance)
+                .ThenBy(rule => rule, NamingRuleAccessibilityListComparer.Instance)
                 .ThenBy(rule => rule, NamingRuleSymbolListComparer.Instance)
                 .ThenBy(rule => rule.Name, StringComparer.OrdinalIgnoreCase)
                 .ThenBy(rule => rule.Name, StringComparer.Ordinal);

--- a/src/Validation/ErrorCatalog.cs
+++ b/src/Validation/ErrorCatalog.cs
@@ -55,6 +55,8 @@ namespace EditorConfig
             Create("EC118", ErrorCategory.Error, Resources.Text.ValidationUnknownStyle);
         public static Error UnusedStyle { get; } =
             Create("EC119", ErrorCategory.Suggestion, Resources.Text.ValidationUnusedStyle);
+        public static Error NamingRuleReordered { get; } =
+            Create("EC120", ErrorCategory.Warning, Resources.Text.NamingRuleReordered);
 
         public static bool TryGetErrorCode(string code, out Error errorCode)
         {

--- a/src/Validation/NamingStyles/Accessibility.cs
+++ b/src/Validation/NamingStyles/Accessibility.cs
@@ -1,0 +1,13 @@
+﻿namespace EditorConfig.Validation.NamingStyles
+{
+    public enum Accessibility
+    {
+        NotApplicable,
+        Private,
+        ProtectedAndInternal,
+        Protected,
+        Internal,
+        ProtectedOrInternal,
+        Public,
+    }
+}

--- a/src/Validation/NamingStyles/EditorConfigNamingStyleParser.cs
+++ b/src/Validation/NamingStyles/EditorConfigNamingStyleParser.cs
@@ -1,0 +1,335 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace EditorConfig.Validation.NamingStyles
+{
+    internal static class EditorConfigNamingStyleParser
+    {
+        public static NamingStylePreferences GetNamingStyles(IEnumerable<Property> properties)
+        {
+            var propertyLookup = properties.ToDictionary(property => property.Keyword.Text.Trim());
+
+            ImmutableArray<SymbolSpecification>.Builder symbolSpecifications = ImmutableArray.CreateBuilder<SymbolSpecification>();
+            ImmutableArray<NamingStyle>.Builder namingStyles = ImmutableArray.CreateBuilder<NamingStyle>();
+            ImmutableArray<SerializableNamingRule>.Builder namingRules = ImmutableArray.CreateBuilder<SerializableNamingRule>();
+
+            foreach (string title in GetRuleTitles(properties))
+            {
+                if (TryGetSymbolSpecification(title, propertyLookup, out SymbolSpecification symbolSpecification)
+                    && TryGetNamingStyle(title, propertyLookup, out NamingStyle namingStyle)
+                    && TryGetNamingRule(title, symbolSpecification, namingStyle, propertyLookup, out SerializableNamingRule namingRule))
+                {
+                    symbolSpecifications.Add(symbolSpecification);
+                    namingStyles.Add(namingStyle);
+                    namingRules.Add(namingRule);
+                }
+            }
+
+            return new NamingStylePreferences(
+                symbolSpecifications.ToImmutable(),
+                namingStyles.ToImmutable(),
+                namingRules.ToImmutable());
+        }
+
+        private static IEnumerable<string> GetRuleTitles(IEnumerable<Property> properties)
+        {
+            IEnumerable<string> titles = from property in properties
+                                         let name = property.Keyword.Text.Trim()
+                                         where name.StartsWith("dotnet_naming_rule.", StringComparison.Ordinal)
+                                         let nameSplit = name.Split('.')
+                                         where nameSplit.Length == 3
+                                         select nameSplit[1];
+            return titles.Distinct();
+        }
+
+        private static bool TryGetSymbolSpecification(string title, Dictionary<string, Property> propertyLookup, out SymbolSpecification symbolSpecification)
+        {
+            symbolSpecification = null;
+            if (!TryGetSymbolSpecificationNameForNamingRule(out string symbolSpecificationName))
+            {
+                return false;
+            }
+
+            symbolSpecification = new SymbolSpecification(
+                id: null,
+                symbolSpecificationName,
+                symbolKindList: GetSymbolsApplicableKinds(),
+                accessibilityList: GetSymbolsApplicableAccessibilities(),
+                modifiers: GetSymbolsRequiredModifiers());
+            return true;
+
+            // Local functions
+            bool TryGetSymbolSpecificationNameForNamingRule(out string name)
+            {
+                if (propertyLookup.TryGetValue($"dotnet_naming_rule.{title}.symbols", out Property nameProperty))
+                {
+                    name = nameProperty.Value.Text.Trim();
+                    return name != null;
+                }
+
+                name = null;
+                return false;
+            }
+
+            ImmutableArray<SymbolKindOrTypeKind> GetSymbolsApplicableKinds()
+            {
+                if (propertyLookup.TryGetValue($"dotnet_naming_symbols.{symbolSpecificationName}.applicable_kinds", out Property applicableKindsProperty))
+                {
+                    return ParseSymbolKindList(applicableKindsProperty?.Value.Text.Trim() ?? "");
+                }
+
+                return SymbolSpecification.DefaultApplicableSymbolKindList;
+            }
+
+            ImmutableArray<SymbolKindOrTypeKind> ParseSymbolKindList(string applicableKinds)
+            {
+                if (applicableKinds is null)
+                {
+                    return ImmutableArray<SymbolKindOrTypeKind>.Empty;
+                }
+
+                if (applicableKinds == "*")
+                {
+                    return SymbolSpecification.DefaultApplicableSymbolKindList;
+                }
+
+                ImmutableArray<SymbolKindOrTypeKind>.Builder result = ImmutableArray.CreateBuilder<SymbolKindOrTypeKind>();
+                foreach (string applicableKind in applicableKinds.Split(','))
+                {
+                    switch (applicableKind.Trim())
+                    {
+                        case "class":
+                            result.Add(SymbolKindOrTypeKind.Class);
+                            break;
+                        case "struct":
+                            result.Add(SymbolKindOrTypeKind.Struct);
+                            break;
+                        case "interface":
+                            result.Add(SymbolKindOrTypeKind.Interface);
+                            break;
+                        case "enum":
+                            result.Add(SymbolKindOrTypeKind.Enum);
+                            break;
+                        case "property":
+                            result.Add(SymbolKindOrTypeKind.Property);
+                            break;
+                        case "method":
+                            result.Add(SymbolKindOrTypeKind.Method);
+                            break;
+                        case "local_function":
+                            result.Add(SymbolKindOrTypeKind.LocalFunction);
+                            break;
+                        case "field":
+                            result.Add(SymbolKindOrTypeKind.Field);
+                            break;
+                        case "event":
+                            result.Add(SymbolKindOrTypeKind.Event);
+                            break;
+                        case "delegate":
+                            result.Add(SymbolKindOrTypeKind.Delegate);
+                            break;
+                        case "parameter":
+                            result.Add(SymbolKindOrTypeKind.Parameter);
+                            break;
+                        case "type_parameter":
+                            result.Add(SymbolKindOrTypeKind.TypeParameter);
+                            break;
+                        case "namespace":
+                            result.Add(SymbolKindOrTypeKind.Namespace);
+                            break;
+                        case "local":
+                            result.Add(SymbolKindOrTypeKind.Local);
+                            break;
+                        default:
+                            break;
+                    }
+                }
+
+                return result.ToImmutable();
+            }
+
+            ImmutableArray<Accessibility> GetSymbolsApplicableAccessibilities()
+            {
+                if (propertyLookup.TryGetValue($"dotnet_naming_symbols.{symbolSpecificationName}.applicable_accessibilities", out Property accessibilitiesProperty))
+                {
+                    return ParseAccessibilityKindList(accessibilitiesProperty?.Value.Text.Trim() ?? string.Empty);
+                }
+
+                return SymbolSpecification.DefaultApplicableAccessibilityList;
+            }
+
+            ImmutableArray<Accessibility> ParseAccessibilityKindList(string accessibilities)
+            {
+                if (accessibilities is null)
+                {
+                    return ImmutableArray<Accessibility>.Empty;
+                }
+
+                if (accessibilities == "*")
+                {
+                    return SymbolSpecification.DefaultApplicableAccessibilityList;
+                }
+
+                ImmutableArray<Accessibility>.Builder result = ImmutableArray.CreateBuilder<Accessibility>();
+                foreach (string accessibility in accessibilities.Split(','))
+                {
+                    switch (accessibility.Trim())
+                    {
+                        case "public":
+                            result.Add(Accessibility.Public);
+                            break;
+                        case "internal":
+                        case "friend":
+                            result.Add(Accessibility.Internal);
+                            break;
+                        case "private":
+                            result.Add(Accessibility.Private);
+                            break;
+                        case "protected":
+                            result.Add(Accessibility.Protected);
+                            break;
+                        case "protected_internal":
+                        case "protected_friend":
+                            result.Add(Accessibility.ProtectedOrInternal);
+                            break;
+                        case "private_protected":
+                            result.Add(Accessibility.ProtectedAndInternal);
+                            break;
+                        case "local":
+                            result.Add(Accessibility.NotApplicable);
+                            break;
+                        default:
+                            break;
+                    }
+                }
+
+                return result.ToImmutable();
+            }
+
+            ImmutableArray<ModifierKind> GetSymbolsRequiredModifiers()
+            {
+                if (propertyLookup.TryGetValue($"dotnet_naming_symbols.{symbolSpecificationName}.required_modifiers", out Property modifiersProperty))
+                {
+                    return ParseModifiers(modifiersProperty?.Value.Text.Trim() ?? string.Empty);
+                }
+
+                return ImmutableArray<ModifierKind>.Empty;
+            }
+
+            ImmutableArray<ModifierKind> ParseModifiers(string modifiers)
+            {
+                if (modifiers is null)
+                {
+                    return ImmutableArray<ModifierKind>.Empty;
+                }
+
+                ImmutableArray<ModifierKind>.Builder result = ImmutableArray.CreateBuilder<ModifierKind>();
+                foreach (string modifier in modifiers.Split(','))
+                {
+                    switch (modifier.Trim())
+                    {
+                        case "abstract":
+                        case "must_inherit":
+                            result.Add(ModifierKind.IsAbstract);
+                            break;
+                        case "async":
+                            result.Add(ModifierKind.IsAsync);
+                            break;
+                        case "const":
+                            result.Add(ModifierKind.IsConst);
+                            break;
+                        case "readonly":
+                            result.Add(ModifierKind.IsReadOnly);
+                            break;
+                        case "static":
+                        case "shared":
+                            result.Add(ModifierKind.IsStatic);
+                            break;
+                        default:
+                            break;
+                    }
+                }
+
+                return result.ToImmutable();
+            }
+        }
+
+        private static bool TryGetNamingStyle(string title, Dictionary<string, Property> propertyLookup, out NamingStyle namingStyle)
+        {
+            namingStyle = default;
+            if (!TryGetNamingStyleNameForNamingRule(out _))
+            {
+                return false;
+            }
+
+            namingStyle = new NamingStyle(Guid.NewGuid());
+            return true;
+
+            // Local functions
+            bool TryGetNamingStyleNameForNamingRule(out string name)
+            {
+                if (propertyLookup.TryGetValue($"dotnet_naming_rule.{title}.style", out Property nameProperty))
+                {
+                    name = nameProperty.Value.Text.Trim();
+                    return name != null;
+                }
+
+                name = null;
+                return false;
+            }
+        }
+
+        private static bool TryGetNamingRule(string title, SymbolSpecification symbolSpecification, NamingStyle namingStyle, Dictionary<string, Property> propertyLookup, out SerializableNamingRule namingRule)
+        {
+            if (!TryGetRuleSeverity(out ReportDiagnostic enforcementLevel))
+            {
+                namingRule = null;
+                return false;
+            }
+
+            namingRule = new SerializableNamingRule()
+            {
+                Name = title,
+                EnforcementLevel = enforcementLevel,
+                NamingStyleID = namingStyle.ID,
+                SymbolSpecificationID = symbolSpecification.ID,
+            };
+            return true;
+
+            // Local functions
+            bool TryGetRuleSeverity(out ReportDiagnostic severity)
+            {
+                if (propertyLookup.TryGetValue($"dotnet_naming_rule.{title}.severity", out Property severityProperty))
+                {
+                    severity = ParseEnforcementLevel(severityProperty?.Value.Text.Trim() ?? string.Empty);
+                    return true;
+                }
+
+                severity = default;
+                return false;
+            }
+
+            ReportDiagnostic ParseEnforcementLevel(string severity)
+            {
+                switch (severity.Trim())
+                {
+                    case "none":
+                        return ReportDiagnostic.Suppress;
+                    case "refactoring":
+                    case "silent":
+                        return ReportDiagnostic.Hidden;
+                    case "suggestion":
+                        return ReportDiagnostic.Info;
+                    case "warning":
+                        return ReportDiagnostic.Warn;
+                    case "error":
+                        return ReportDiagnostic.Error;
+                    default:
+                        return ReportDiagnostic.Hidden;
+                }
+            }
+        }
+    }
+}

--- a/src/Validation/NamingStyles/EditorConfigNamingStyleParser.cs
+++ b/src/Validation/NamingStyles/EditorConfigNamingStyleParser.cs
@@ -225,7 +225,7 @@ namespace EditorConfig.Validation.NamingStyles
                     return ImmutableArray<ModifierKind>.Empty;
                 }
 
-                ImmutableArray<ModifierKind>.Builder result = ImmutableArray.CreateBuilder<ModifierKind>();
+                var result = new List<ModifierKind>();
                 foreach (string modifier in modifiers.Split(','))
                 {
                     switch (modifier.Trim())
@@ -239,6 +239,8 @@ namespace EditorConfig.Validation.NamingStyles
                             break;
                         case "const":
                             result.Add(ModifierKind.IsConst);
+                            result.Add(ModifierKind.IsReadOnly);
+                            result.Add(ModifierKind.IsStatic);
                             break;
                         case "readonly":
                             result.Add(ModifierKind.IsReadOnly);
@@ -252,7 +254,7 @@ namespace EditorConfig.Validation.NamingStyles
                     }
                 }
 
-                return result.ToImmutable();
+                return result.Distinct().ToImmutableArray();
             }
         }
 

--- a/src/Validation/NamingStyles/ModifierKind.cs
+++ b/src/Validation/NamingStyles/ModifierKind.cs
@@ -1,0 +1,11 @@
+﻿namespace EditorConfig.Validation.NamingStyles
+{
+    public enum ModifierKind
+    {
+        IsAbstract,
+        IsStatic,
+        IsAsync,
+        IsReadOnly,
+        IsConst,
+    }
+}

--- a/src/Validation/NamingStyles/NamingRule.cs
+++ b/src/Validation/NamingStyles/NamingRule.cs
@@ -1,0 +1,18 @@
+﻿namespace EditorConfig.Validation.NamingStyles
+{
+    internal readonly struct NamingRule
+    {
+        public readonly string Name;
+        public readonly SymbolSpecification SymbolSpecification;
+        public readonly NamingStyle NamingStyle;
+        public readonly ReportDiagnostic EnforcementLevel;
+
+        public NamingRule(string name, SymbolSpecification symbolSpecification, NamingStyle namingStyle, ReportDiagnostic enforcementLevel)
+        {
+            Name = name;
+            SymbolSpecification = symbolSpecification;
+            NamingStyle = namingStyle;
+            EnforcementLevel = enforcementLevel;
+        }
+    }
+}

--- a/src/Validation/NamingStyles/NamingStyle.cs
+++ b/src/Validation/NamingStyles/NamingStyle.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace EditorConfig.Validation.NamingStyles
+{
+    internal readonly struct NamingStyle
+    {
+        public NamingStyle(Guid id)
+        {
+            ID = id;
+        }
+
+        public Guid ID { get; }
+    }
+}

--- a/src/Validation/NamingStyles/NamingStylePreferences.cs
+++ b/src/Validation/NamingStyles/NamingStylePreferences.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace EditorConfig.Validation.NamingStyles
+{
+    internal class NamingStylePreferences
+    {
+        public readonly ImmutableArray<SymbolSpecification> SymbolSpecifications;
+        public readonly ImmutableArray<NamingStyle> NamingStyles;
+        public readonly ImmutableArray<SerializableNamingRule> NamingRules;
+
+        private readonly Lazy<NamingStyleRules> _lazyRules;
+
+        internal NamingStylePreferences(
+            ImmutableArray<SymbolSpecification> symbolSpecifications,
+            ImmutableArray<NamingStyle> namingStyles,
+            ImmutableArray<SerializableNamingRule> namingRules)
+        {
+            SymbolSpecifications = symbolSpecifications;
+            NamingStyles = namingStyles;
+            NamingRules = namingRules;
+
+            _lazyRules = new Lazy<NamingStyleRules>(CreateRules, isThreadSafe: true);
+        }
+
+        public NamingStyleRules Rules => _lazyRules.Value;
+
+        internal NamingStyle GetNamingStyle(Guid namingStyleID)
+            => NamingStyles.Single(s => s.ID == namingStyleID);
+
+        internal SymbolSpecification GetSymbolSpecification(Guid symbolSpecificationID)
+            => SymbolSpecifications.Single(s => s.ID == symbolSpecificationID);
+
+        private NamingStyleRules CreateRules()
+            => new NamingStyleRules(NamingRules.Select(r => r.GetRule(this)).ToImmutableArray());
+    }
+}

--- a/src/Validation/NamingStyles/NamingStyleRules.cs
+++ b/src/Validation/NamingStyles/NamingStyleRules.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Immutable;
+
+namespace EditorConfig.Validation.NamingStyles
+{
+    internal readonly struct NamingStyleRules
+    {
+        public NamingStyleRules(ImmutableArray<NamingRule> namingRules)
+        {
+            NamingRules = namingRules;
+        }
+
+        public ImmutableArray<NamingRule> NamingRules { get; }
+    }
+}

--- a/src/Validation/NamingStyles/ReportDiagnostic.cs
+++ b/src/Validation/NamingStyles/ReportDiagnostic.cs
@@ -1,0 +1,35 @@
+﻿namespace EditorConfig.Validation.NamingStyles
+{
+    internal enum ReportDiagnostic
+    {
+        /// <summary>
+        /// Report a diagnostic by default.
+        /// </summary>
+        Default = 0,
+
+        /// <summary>
+        /// Report a diagnostic as an error.  
+        /// </summary>
+        Error = 1,
+
+        /// <summary>
+        /// Report a diagnostic as a warning even though /warnaserror is specified.
+        /// </summary>
+        Warn = 2,
+
+        /// <summary>
+        /// Report a diagnostic as an info.
+        /// </summary>
+        Info = 3,
+
+        /// <summary>
+        /// Report a diagnostic as hidden.
+        /// </summary>
+        Hidden = 4,
+
+        /// <summary>
+        /// Suppress a diagnostic.
+        /// </summary>
+        Suppress = 5,
+    }
+}

--- a/src/Validation/NamingStyles/SerializableNamingRule.cs
+++ b/src/Validation/NamingStyles/SerializableNamingRule.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace EditorConfig.Validation.NamingStyles
+{
+    internal sealed class SerializableNamingRule
+    {
+        public string Name;
+        public Guid SymbolSpecificationID;
+        public Guid NamingStyleID;
+        public ReportDiagnostic EnforcementLevel;
+
+        public NamingRule GetRule(NamingStylePreferences info)
+        {
+            return new NamingRule(
+                Name,
+                info.GetSymbolSpecification(SymbolSpecificationID),
+                info.GetNamingStyle(NamingStyleID),
+                EnforcementLevel);
+        }
+    }
+}

--- a/src/Validation/NamingStyles/SymbolKindOrTypeKind.cs
+++ b/src/Validation/NamingStyles/SymbolKindOrTypeKind.cs
@@ -1,0 +1,37 @@
+﻿namespace EditorConfig.Validation.NamingStyles
+{
+    internal enum SymbolKindOrTypeKind
+    {
+        #region Symbol kinds
+
+        Namespace,
+        Event,
+        Field,
+        Local,
+        Method,
+        Parameter,
+        Property,
+
+        #endregion
+
+        #region Type kinds
+
+        Class,
+        Delegate,
+        Enum,
+        Interface,
+        Module,
+        Pointer,
+        Struct,
+        TypeParameter,
+
+        #endregion
+
+        #region Method kinds
+
+        Ordinary,
+        LocalFunction,
+
+        #endregion
+    }
+}

--- a/src/Validation/NamingStyles/SymbolSpecification.cs
+++ b/src/Validation/NamingStyles/SymbolSpecification.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Immutable;
+
+namespace EditorConfig.Validation.NamingStyles
+{
+    internal sealed class SymbolSpecification
+    {
+        internal static readonly ImmutableArray<SymbolKindOrTypeKind> DefaultApplicableSymbolKindList = ImmutableArray.Create(
+            SymbolKindOrTypeKind.Namespace,
+            SymbolKindOrTypeKind.Class,
+            SymbolKindOrTypeKind.Struct,
+            SymbolKindOrTypeKind.Interface,
+            SymbolKindOrTypeKind.Delegate,
+            SymbolKindOrTypeKind.Enum,
+            SymbolKindOrTypeKind.Module,
+            SymbolKindOrTypeKind.Pointer,
+            SymbolKindOrTypeKind.Property,
+            SymbolKindOrTypeKind.Ordinary,
+            SymbolKindOrTypeKind.LocalFunction,
+            SymbolKindOrTypeKind.Field,
+            SymbolKindOrTypeKind.Event,
+            SymbolKindOrTypeKind.Parameter,
+            SymbolKindOrTypeKind.TypeParameter,
+            SymbolKindOrTypeKind.Local);
+
+        internal static readonly ImmutableArray<Accessibility> DefaultApplicableAccessibilityList = ImmutableArray.Create(
+            Accessibility.NotApplicable,
+            Accessibility.Public,
+            Accessibility.Internal,
+            Accessibility.Private,
+            Accessibility.Protected,
+            Accessibility.ProtectedAndInternal,
+            Accessibility.ProtectedOrInternal);
+
+        internal static readonly ImmutableArray<ModifierKind> DefaultRequiredModifierList = ImmutableArray<ModifierKind>.Empty;
+
+        public Guid ID { get; }
+        public string Name { get; }
+
+        public ImmutableArray<SymbolKindOrTypeKind> ApplicableSymbolKindList { get; }
+        public ImmutableArray<Accessibility> ApplicableAccessibilityList { get; }
+        public ImmutableArray<ModifierKind> RequiredModifierList { get; }
+
+        public SymbolSpecification(
+            Guid? id,
+            string symbolSpecName,
+            ImmutableArray<SymbolKindOrTypeKind> symbolKindList,
+            ImmutableArray<Accessibility> accessibilityList,
+            ImmutableArray<ModifierKind> modifiers)
+        {
+            ID = id ?? Guid.NewGuid();
+            Name = symbolSpecName;
+            ApplicableSymbolKindList = symbolKindList.IsDefault ? DefaultApplicableSymbolKindList : symbolKindList;
+            ApplicableAccessibilityList = accessibilityList.IsDefault ? DefaultApplicableAccessibilityList : accessibilityList;
+            RequiredModifierList = modifiers.IsDefault ? DefaultRequiredModifierList : modifiers;
+        }
+    }
+}


### PR DESCRIPTION
The compiler implementation of .editorconfig changes the way naming rules are ordered. This pull request implements an analyzer to report a warning when the .editorconfig file contains two rules that will be evaluated in reverse order from their location in the .editorconfig file.

The warning emitted for this situation reads as follows:

> Naming rule '{0}' was reordered relative to overlapping rule '{1}'. Elements which match both will be validated against rule '{0}' starting with Visual Studio 2019 version 16.3.