### PR TITLE
Fix typo

### DIFF
--- a/src/Schema/EditorConfig.json
+++ b/src/Schema/EditorConfig.json
@@ -399,7 +399,7 @@
     {
       "name": "csharp_prefer_braces",
       "description": "Prefer braces when possible.",
-      "values": [ true, false, "when-multiline" ],
+      "values": [ true, false, "when_multiline" ],
       "defaultValue": [ true ],
       "severity": true,
       "defaultSeverity": "silent",


### PR DESCRIPTION
According to both [.NET coding convention settings for EditorConfig](https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-language-conventions?view=vs-2019#code-block-preferences) as well as dotnet/roslyn#31599, the value is `when_multiline` with an underscore.